### PR TITLE
add a ->download method

### DIFF
--- a/lib/JMAP/Tester/Result/Download.pm
+++ b/lib/JMAP/Tester/Result/Download.pm
@@ -19,8 +19,8 @@ sub is_success { 1 }
 has bytes_ref => (
   is   => 'ro',
   lazy => 1,
-  default => {
-    my $str = $self->http_response->decoded_content(charset => 'none');
+  default => sub {
+    my $str = $_[0]->http_response->decoded_content(charset => 'none');
     return $str;
   },
 );


### PR DESCRIPTION
The download_uri is actually a template.  If we convert the string
given during initialization into a URI object eagerly, we'll cause
the {'s and }'s to be %-encoded, which is no good.  Really, we only
needed URI objects for cookie-setting, which is probably on its way
out anyway.  So, this commit falls back to strings.

->download takes the same parameters that might appear in the
template and fills it out.  The Download result has a bytes_ref,
which may or may not be the best interface, but it seems easy to use
for testing, and the HTTP response is there anyway.