### PR TITLE
$set_sentence->assert_no_errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+        - Set sentences now have an assert_no_errors method that throws a
+          error-dumping abort if any part of the setFoos method did not succeed
+        - $set->VERB_errors now always returns an empty hashref if there are
+          errors, even if the server returned nothing or null
 
 0.008     2017-01-01 12:00:12-05:00 America/New_York
         - update minimum required JSON::Typist

--- a/lib/JMAP/Tester/Abort.pm
+++ b/lib/JMAP/Tester/Abort.pm
@@ -23,9 +23,16 @@ has message => (
   required => 1,
 );
 
+has diagnostics => (
+  is => 'ro',
+);
+
 sub as_test_abort_events {
   return [
-    [ Ok => (pass => 0, name => $_[0]->message) ]
+    [ Ok => (pass => 0, name => $_[0]->message) ],
+    ($_[0]->diagnostics
+      ? (map {; [ Diag => (message => $_) ] } @{ $_[0]->diagnostics })
+      : ()),
   ];
 }
 

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -62,7 +62,7 @@ sub _index_setup {
 
     if (defined $prev_cid && $prev_cid ne $cid) {
       # We're transition from cid1 to cid2. -- rjbs, 2016-04-08
-      Carp::cluck("client_id <$cid> appears in non-contiguous positions")
+      abort("client_id <$cid> appears in non-contiguous positions")
         if $cid_indices{$cid};
 
       $next_para_idx++;

--- a/lib/JMAP/Tester/Response/Paragraph.pm
+++ b/lib/JMAP/Tester/Response/Paragraph.pm
@@ -20,6 +20,20 @@ matching client ids.
 
 =cut
 
+sub client_id {
+  my ($self) = @_;
+  $self->_sentences->[0]->client_id;
+}
+
+sub BUILD {
+  Carp::confess("tried to build 0-sentence paragraph")
+    unless @{ $_[0]->_sentences };
+
+  my $client_id = $_[0]->_sentences->[0]->client_id;
+  Carp::confess("tried to build paragraph with non-uniform client_ids")
+    if grep {; $_->client_id ne $client_id } @{ $_[0]->_sentences };
+}
+
 has sentences => (is => 'bare', reader => '_sentences', required => 1);
 
 has _json_typist => (

--- a/lib/JMAP/Tester/Response/Paragraph.pm
+++ b/lib/JMAP/Tester/Response/Paragraph.pm
@@ -4,6 +4,8 @@ package JMAP::Tester::Response::Paragraph;
 
 use Moo;
 
+use JMAP::Tester::Abort 'abort';
+
 =head1 OVERVIEW
 
 These objects represent paragraphs in the JMAP response.  That is, if your
@@ -26,11 +28,11 @@ sub client_id {
 }
 
 sub BUILD {
-  Carp::confess("tried to build 0-sentence paragraph")
+  abort("tried to build 0-sentence paragraph")
     unless @{ $_[0]->_sentences };
 
   my $client_id = $_[0]->_sentences->[0]->client_id;
-  Carp::confess("tried to build paragraph with non-uniform client_ids")
+  abort("tried to build paragraph with non-uniform client_ids")
     if grep {; $_->client_id ne $client_id } @{ $_[0]->_sentences };
 }
 

--- a/lib/JMAP/Tester/Response/Sentence.pm
+++ b/lib/JMAP/Tester/Response/Sentence.pm
@@ -99,6 +99,7 @@ sub as_set {
     name         => $_[0]->name,
     arguments    => $_[0]->arguments,
     client_id    => $_[0]->client_id,
+    _json_typist => $_[0]->_json_typist,
   });
 }
 

--- a/lib/JMAP/Tester/Response/Sentence/Set.pm
+++ b/lib/JMAP/Tester/Response/Sentence/Set.pm
@@ -137,8 +137,8 @@ sub not_created_ids   { keys %{ $_[0]{arguments}{notCreated} }   }
 sub not_updated_ids   { keys %{ $_[0]{arguments}{notUpdated} }   }
 sub not_destroyed_ids { keys %{ $_[0]{arguments}{notDestroyed} } }
 
-sub create_errors     { $_[0]{arguments}{notCreated}   }
-sub update_errors     { $_[0]{arguments}{notUpdated}   }
-sub destroy_errors    { $_[0]{arguments}{notDestroyed} }
+sub create_errors     { $_[0]{arguments}{notCreated}   // {} }
+sub update_errors     { $_[0]{arguments}{notUpdated}   // {} }
+sub destroy_errors    { $_[0]{arguments}{notDestroyed} // {} }
 
 1;

--- a/lib/JMAP/Tester/Response/Sentence/Set.pm
+++ b/lib/JMAP/Tester/Response/Sentence/Set.pm
@@ -16,6 +16,13 @@ has name      => (is => 'ro', required => 1);
 has arguments => (is => 'ro', required => 1);
 has client_id => (is => 'ro', required => 1);
 
+has _json_typist => (
+  is => 'ro',
+  handles => {
+    _strip_json_types => 'strip_types',
+  },
+);
+
 =method new_state
 
 This returns the C<newState> in the result.

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,6 +6,7 @@ use JSON::Typist 0.005; # $typist->number
 
 use Test::Deep;
 use Test::Deep::JType 0.005; # jstr() in both want and have
+use Test::Fatal;
 use Test::More;
 use Test::Abortable 'subtest';
 
@@ -20,15 +21,76 @@ subtest "the basic basics" => sub {
   my $res = JMAP::Tester::Response->new({
     _json_typist => $typist,
     struct => [
-      [ atePies => { howMany => jnum(100), tastiestPieId => jstr(123) }, 'a' ],
-      [ platesDiscarded => { notDiscarded => [] }, 'a' ],
+      [ jstr('atePies'),
+        { howMany => jnum(100), tastiestPieId => jstr(123) },
+        jstr('a') ],
+      [ jstr('platesDiscarded'),
+        { notDiscarded => [] },
+        jstr('a') ],
 
-      [ drankBeer => { abv => jnum(0.02) }, 'b' ],
+      [ jstr('drankBeer'),
+        { abv => jnum(0.02) },
+        jstr('b') ],
 
-      [ tookNap => { successfulDuration => jnum(2) }, 'c' ],
-      [ dreamed => { about => jstr("more pie") }, 'c' ],
+      [ jstr('tookNap'),
+        { successfulDuration => jnum(2) },
+        jstr('c') ],
+      [ jstr('dreamed'),
+        { about => jstr("more pie") },
+        jstr('c') ],
     ],
   });
+
+  for my $pair (
+    [ response  => sub { my $meth = shift; $res->$meth->[0] } ],
+    [ paragraph => sub { my $meth = shift; $res->paragraph(0)->$meth->[0] } ],
+    [ sentence  => sub { my $meth = shift; $res->sentence(0)->$meth } ],
+  ) {
+    subtest "structure tests on $pair->[0]" => sub {
+      my $call = $pair->[1];
+
+      jcmp_deeply(
+        $call->('as_struct'),
+        [
+          jstr('atePies'),
+          { howMany => jnum(100), tastiestPieId => jstr(123) },
+          jstr('a'),
+        ],
+        "as_struct",
+      );
+
+      my $pair_method = $pair->[0] eq 'sentence' ? 'pair' : 'pairs';
+      jcmp_deeply(
+        $call->("as_${pair_method}"),
+        [
+          jstr('atePies'),
+          { howMany => jnum(100), tastiestPieId => jstr(123) },
+        ],
+        "as_${pair_method}",
+      );
+
+      jcmp_deeply(
+        $call->('as_stripped_struct'),
+        [ 'atePies', { howMany => 100, tastiestPieId => 123 }, 'a' ],
+        "as_stripped_struct",
+      );
+
+      jcmp_deeply(
+        $call->("as_stripped_${pair_method}"),
+        [ 'atePies', { howMany => 100, tastiestPieId => 123 } ],
+        "as_stripped_${pair_method}",
+      );
+    }
+  }
+
+  ok($res->is_success, "a JMAP::Tester::Response is a success");
+
+  is($res->sentence(0)->name, "atePies",         "s0 name");
+  is($res->sentence(1)->name, "platesDiscarded", "s1 name");
+  is($res->sentence(2)->name, "drankBeer",       "s2 name");
+  is($res->sentence(3)->name, "tookNap",         "s3 name");
+  is($res->sentence(4)->name, "dreamed",         "s4 name");
+  is($res->sentence(5),       undef,             "s5 does not exist");
 
   my ($p0, $p1, $p2) = $res->assert_n_paragraphs(3);
 
@@ -37,6 +99,13 @@ subtest "the basic basics" => sub {
   is($p1->sentence(0)->name, "drankBeer",       "p1 s0 name");
   is($p2->sentence(0)->name, "tookNap",         "p2 s0 name");
   is($p2->sentence(1)->name, "dreamed",         "p2 s1 name");
+  is($p2->sentence(2),       undef,             "p2 s2 does not exist");
+
+  is($res->paragraph(0)->client_id, 'a',    "p0 cid");
+  is($res->paragraph(3),            undef,  "p3 does not exist");
+
+  my @p2_sentences = $p2->sentences;
+  is(@p2_sentences, 2, "p2 sentences");
 };
 
 subtest "old style updated" => sub {
@@ -52,11 +121,11 @@ subtest "old style updated" => sub {
     my $res = JMAP::Tester::Response->new({
       _json_typist => $typist,
       struct => [
-        [ setPieces => { updated => $kinds{$kind} }, 'a' ]
+        [ piecesSet => { updated => $kinds{$kind} }, 'a' ]
       ],
     });
 
-    my $s = $res->single_sentence('setPieces')->as_set;
+    my $s = $res->single_sentence('piecesSet')->as_set;
 
     is_deeply(
       [ sort $s->updated_ids ],
@@ -105,7 +174,7 @@ subtest "set sentence assert_no_errors" => sub {
         _json_typist => $typist,
         struct => [
           [
-            setPieces => {
+            piecesSet => {
               updated    => { foo => undef },
               notUpdated => { fail => { type => jstr("internalJoke") } },
               notDestroyed => { tick => { type => jstr("nighInvulnerabile") } },
@@ -115,7 +184,7 @@ subtest "set sentence assert_no_errors" => sub {
         ],
       });
 
-      my $s = $res->single_sentence('setPieces')->as_set;
+      my $s = $res->single_sentence('piecesSet')->as_set;
 
       $s->assert_no_errors;
 
@@ -135,6 +204,57 @@ subtest "set sentence assert_no_errors" => sub {
   is(@diags, 2, "we got two distinct diagnostics");
   like($diags[0]->message, qr/notDestroyed/, "...one about destroys");
   like($diags[1]->message, qr/notUpdated/, "...one about destroys");
+};
+
+subtest "miscellaneous error conditions" => sub {
+  my $res_1 = JMAP::Tester::Response->new({
+    _json_typist => $typist,
+    struct => [
+      [ welcome => { all => jstr('refugees') }, jstr('xyzzy') ],
+    ],
+  });
+
+  my $res_2 = JMAP::Tester::Response->new({
+    _json_typist => $typist,
+    struct => [
+      [ welcome => { all  => jstr('refugees') }, jstr('xyzzy') ],
+      [ goodBye => { blue => jstr('skye') }, jstr('a') ],
+    ],
+  });
+
+  {
+    my $error = exception { $res_1->single_sentence('foo') };
+    like(
+      $error,
+      qr/single sentence has name "welcome"/,
+      "single_sentence checks name",
+    );
+  }
+
+  {
+    my $error = exception { $res_2->single_sentence('foo') };
+    like($error, qr/there are 2 sentences/, "single_sentence checks count");
+  }
+
+  {
+    my $error = exception { $res_2->assert_n_paragraphs(10) };
+    like(
+      $error,
+      qr/expected 10 paragraphs but got 2/,
+      "assert_n_paragraphs",
+    );
+  }
+
+  {
+    my $ok = eval {
+      $res_2->paragraph_by_client_id('xyzzy')->single('welcome');
+      $res_2->paragraph_by_client_id('a')->single('goodBye');
+      1;
+    };
+
+    my $error = $@;
+    ok($ok, "paragraph_by_client_id") or diag $error;
+  }
 };
 
 done_testing;


### PR DESCRIPTION
This makes it easy for the tester to assert that a *setFoos* succeeded completely.  Code like:

```perl
subtest "set sentence assert_no_errors" => sub {
  my $res = JMAP::Tester::Response->new({
    _json_typist => $typist,
    struct => [
      [
        setPieces => {
          updated    => { foo => undef },
          notUpdated => { fail => { type => jstr("internalJoke") } },
          notDestroyed => { tick => { type => jstr("nighInvulnerabile") } },
        },
        'a',
      ]
    ],
  });

  my $s = $res->single_sentence('setPieces')->as_set;

  $s->assert_no_errors;

  pass("never reached");
};
```

Produces test results like:

```
# set sentence assert_no_errors
    not ok 1 - errors found in setPieces sentence
    # notUpdated: {
    #   'fail' => {
    #               'type' => 'internalJoke'
    #             }
    # }
    # notDestroyed: {
    #   'tick' => {
    #               'type' => 'nighInvulnerabile'
    #             }
    # }
    1..1
not ok 4 - set sentence assert_no_errors
```