### PR TITLE
When logging out we need to clear our _access_token

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -583,6 +583,8 @@ sub logout {
   );
 
   if ($logout_res->code == 204) {
+    $self->_access_token(undef);
+
     return JMAP::Tester::Result::Logout->new({
       http_response => $logout_res,
     });


### PR DESCRIPTION
Otherwise we'll continue to send our 'Authorization' header, which, since
it's no longer attached to a valid session, may cause us to get a bad
response.