### PR TITLE
Allow passing the \%rest parameter of HTTP::Header's set_cookie

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -141,6 +141,7 @@ sub _set_cookie {
     ($uri->port == 443 ? 1 : 0),
     86400,
     0,
+    $arg->{rest} || {},
   );
 }
 


### PR DESCRIPTION
I have tests that fail because HTTP Only isn't set on some of the cookies, this allows me to do so.

(Perhaps JMAP::Tester should just set it?