### PR TITLE
Don't use allow_blessed. This avoids surprising serializations

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -86,7 +86,7 @@ has json_codec => (
   },
   default => sub {
     require JSON;
-    return JSON->new->utf8->allow_blessed->convert_blessed;
+    return JSON->new->utf8->convert_blessed;
   },
 );
 


### PR DESCRIPTION
convert_blessed means any blessed reference with a TO_JSON method
or string overloading will be serialized as such.

allow_blessed means that such things will fall back to 'null'
instead of throwing an exception.

I think this behaviour is too surprising so let's get rid of
allow_blessed, that way we'll get an exception if we try to
serialize a blessed object.