### PR TITLE
simple_auth() - POST JSON bodies, not x-www-form-urlencoded bodies

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -574,11 +574,9 @@ sub simple_auth {
 
   my $start_res = $self->ua->post(
     $self->authentication_uri,
-    [
-      'Content-Type' => 'application/json; charset=utf-8',
-      'Accept'       => 'application/json',
-      'Content'      => $start_json,
-    ],
+    'Content-Type' => 'application/json; charset=utf-8',
+    'Accept'       => 'application/json',
+    'Content'      => $start_json,
   );
 
   unless ($start_res->code == 200) {
@@ -605,11 +603,9 @@ sub simple_auth {
 
   my $next_res = $self->ua->post(
     $self->authentication_uri,
-    [
-      'Content-Type' => 'application/json; charset=utf-8',
-      'Accept'       => 'application/json',
-      'Content'      => $next_json,
-    ],
+    'Content-Type' => 'application/json; charset=utf-8',
+    'Accept'       => 'application/json',
+    'Content'      => $next_json,
   );
 
   unless ($next_res->code == 201) {


### PR DESCRIPTION
$lwp->post($url, [ ]) treats everything in the [] as form data.

We want to pass in explicit headers and specify the content in
Content => '...'.