### PR TITLE
Add an accept param to download_uri_for

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -428,10 +428,12 @@ Valid arguments are:
 
   blobId    - the blob to download (no default)
   accountId - the account for which we're downloading (no default)
+  type      - the content-type we want the server to provide back (no default)
   name      - the name we want the server to provide back (default: "download")
 
-If the download URI template has a C<blobId> or C<accountId> placeholder but no
-argument for that is given to C<download>, an exception will be thrown.
+If the download URI template has a C<blobId>, C<accountId>, or C<type>
+placeholder but no argument for that is given to C<download>, an exception
+will be thrown.
 
 The return value will either be a L<failure
 object|JMAP::Tester::Result::Failure> or an L<upload
@@ -447,7 +449,7 @@ sub download_uri_for {
   Carp::confess("can't compute download URI without configured download_uri")
     unless my $uri = $self->download_uri;
 
-  for my $param (qw(blobId accountId name)) {
+  for my $param (qw(blobId accountId name type)) {
     next unless $uri =~ /\{$param\}/;
     my $value = $arg->{ $param } // $DL_DEFAULT{ $param };
 


### PR DESCRIPTION
Per the latest JMAP spec, clients can pass ?accept=type in lieu of
passing an Accept header. This makes those easier to generate.