### PR TITLE
Add response_payload method, a generic way to get at the Result's res…

### DIFF
--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -4,7 +4,7 @@ package JMAP::Tester::Response;
 # ABSTRACT: what you get in reply to a succesful JMAP request
 
 use Moo;
-with 'JMAP::Tester::Role::SentenceCollection', 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::SentenceCollection', 'JMAP::Tester::Role::HTTPResult';
 
 use JMAP::Tester::Response::Sentence;
 use JMAP::Tester::Response::Paragraph;

--- a/lib/JMAP/Tester/Result/Auth.pm
+++ b/lib/JMAP/Tester/Result/Auth.pm
@@ -5,7 +5,7 @@ package JMAP::Tester::Result::Auth;
 # ABSTRACT: what you get when you authenticate
 
 use Moo;
-with 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::HTTPResult';
 
 use namespace::clean;
 

--- a/lib/JMAP/Tester/Result/Download.pm
+++ b/lib/JMAP/Tester/Result/Download.pm
@@ -5,7 +5,7 @@ package JMAP::Tester::Result::Download;
 # ABSTRACT: what you get when you download a blob
 
 use Moo;
-with 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::HTTPResult';
 
 use namespace::clean;
 

--- a/lib/JMAP/Tester/Result/Failure.pm
+++ b/lib/JMAP/Tester/Result/Failure.pm
@@ -5,7 +5,7 @@ package JMAP::Tester::Result::Failure;
 # ABSTRACT: what you get when your JMAP request utterly fails
 
 use Moo;
-with 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::HTTPResult';
 
 use namespace::clean;
 

--- a/lib/JMAP/Tester/Result/Logout.pm
+++ b/lib/JMAP/Tester/Result/Logout.pm
@@ -5,7 +5,7 @@ package JMAP::Tester::Result::Logout;
 # ABSTRACT: a successful logout
 
 use Moo;
-with 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::HTTPResult';
 
 use namespace::clean;
 

--- a/lib/JMAP/Tester/Result/Upload.pm
+++ b/lib/JMAP/Tester/Result/Upload.pm
@@ -5,7 +5,7 @@ package JMAP::Tester::Result::Upload;
 # ABSTRACT: what you get when you upload a blob
 
 use Moo;
-with 'JMAP::Tester::Role::Result';
+with 'JMAP::Tester::Role::HTTPResult';
 
 use namespace::clean;
 

--- a/lib/JMAP/Tester/Role/HTTPResult.pm
+++ b/lib/JMAP/Tester/Role/HTTPResult.pm
@@ -1,0 +1,38 @@
+use v5.10.0;
+use warnings;
+package JMAP::Tester::Role::HTTPResult;
+# ABSTRACT: the kind of thing that you get back for an http request
+
+use Moo::Role;
+
+with 'JMAP::Tester::Role::Result';
+
+=head1 OVERVIEW
+
+This is the role consumed by the class of any object returned by
+L<JMAP::Tester>'s C<request> method.  In addition to
+L<JMAP::Tester::Role::Result>, this role provides C<http_response> to
+get at the underlying L<HTTP::Response> object. C<response_payload> will
+come from the C<as_string> method of that object.
+
+=cut
+
+has http_response => (
+  is => 'ro',
+);
+
+=method response_payload
+
+Returns the raw payload of the response, if there is one. Empty string
+otherwise. Mostly this will be C<< $self->http_response->as_string >>
+but other result types may exist that don't have an http_response...
+
+=cut
+
+sub response_payload {
+  my ($self) = @_;
+
+  return $self->http_response ? $self->http_response->as_string : '';
+}
+
+1;

--- a/lib/JMAP/Tester/Role/Result.pm
+++ b/lib/JMAP/Tester/Role/Result.pm
@@ -13,15 +13,12 @@ use namespace::clean;
 
 This is the role consumed by the class of any object returned by JMAP::Tester's
 C<request> method.  Its only guarantee, for now, is an C<is_success> method,
-and an C<http_response> method.
+and a C<response_payload> method.
 
 =cut
 
 requires 'is_success';
-
-has http_response => (
-  is => 'ro',
-);
+requires 'response_payload';
 
 =method assert_successful
 


### PR DESCRIPTION
…ponse

This way if we have responses from different transports, they aren't required
to fill in http_response...