### PR TITLE
abstract UA out, add futures support in 

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -876,4 +876,65 @@ sub logout {
   return $self->return_futures ? $future : $future->$Failsafe->get;
 }
 
+=method http_request
+
+  my $response = $jtest->http_request($http_request);
+
+Sometimes, you may need to make an HTTP request with your existing web
+connection.  This might be to interact with a custom authentication mechanism,
+to access custom endpoints, or just to make very, very specifically crafted
+requests.  For this reasons, C<http_request> exists.
+
+This returns either an HTTP::Response or a Future that will complete to one.
+
+=cut
+
+sub http_request {
+  my ($self, $http_request) = @_;
+
+  my $future = $self->ua->request($self, $http_request, 'misc');
+  return $self->return_futures ? $future : $future->$Failsafe->get;
+}
+
+=method http_get
+
+  my $response = $jtest->http_get($url, $headers);
+
+This method is just sugar for calling C<http_request> to make a GET request for
+the given URL.  C<$headers> is an optional arrayref of headers.
+
+=cut
+
+sub http_get {
+  my ($self, $url, $headers) = @_;
+
+  my $req = HTTP::Request->new(
+    GET => $url,
+    (defined $headers ? $headers : ()),
+  );
+  return $self->http_request($req);
+}
+
+=method http_post
+
+  my $response = $jtest->http_post($url, $body, $headers);
+
+This method is just sugar for calling C<http_request> to make a POST request
+for the given URL.  C<$headers> is an arrayref of headers and C<$body> is the
+byte string to be passed as the body.
+
+=cut
+
+sub http_post {
+  my ($self, $url, $body, $headers) = @_;
+
+  my $req = HTTP::Request->new(
+    POST => $url,
+    $headers // [],
+    $body,
+  );
+
+  return $self->http_request($req);
+}
+
 1;

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -79,7 +79,14 @@ There is also L<JMAP::Tester::Response/"as_stripped_pairs">.
 
 =cut
 
-has return_futures => (
+=attr should_return_futures
+
+If true, this indicates that the various network-accessing methods should
+return L<Future> objects rather than immediate results.
+
+=cut
+
+has should_return_futures => (
   is  => 'ro',
   default => 0,
 );
@@ -260,6 +267,10 @@ L<JMAP::Tester::Response> objects.
 Before the JMAP request is made, each triple is passed to a method called
 C<munge_method_triple>, which can tweak the method however it likes.
 
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
+
 =cut
 
 sub request {
@@ -350,7 +361,7 @@ sub request {
     return Future->done($self->_jresponse_from_hresponse($res));
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 sub munge_method_triple {}
@@ -422,6 +433,10 @@ The return value will either be a L<failure
 object|JMAP::Tester::Result::Failure> or an L<upload
 result|JMAP::Tester::Result::Upload>.
 
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
+
 =cut
 
 sub upload {
@@ -482,7 +497,7 @@ sub upload {
     );
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method download
@@ -503,6 +518,10 @@ will be thrown.
 The return value will either be a L<failure
 object|JMAP::Tester::Result::Failure> or an L<upload
 result|JMAP::Tester::Result::Download>.
+
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
 
 =cut
 
@@ -590,12 +609,16 @@ sub download {
     );
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method simple_auth
 
   my $auth_struct = $tester->simple_auth($username, $password);
+
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
 
 =cut
 
@@ -723,7 +746,7 @@ sub simple_auth {
     return Future->done($auth);
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method update_client_session
@@ -733,6 +756,10 @@ sub simple_auth {
 
 This method fetches the content at the authentication endpoint and uses it to
 configure the tester's target URIs and signing keys.
+
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
 
 =cut
 
@@ -772,7 +799,7 @@ sub update_client_session {
     return Future->done($auth);
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method configure_from_client_session
@@ -834,6 +861,10 @@ sub configure_from_client_session {
 This method attempts to log out from the server by sending a C<DELETE> request
 to the authentication URI.
 
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the Result.
+
 =cut
 
 sub logout {
@@ -873,7 +904,7 @@ sub logout {
     );
   });
 
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method http_request
@@ -885,7 +916,9 @@ connection.  This might be to interact with a custom authentication mechanism,
 to access custom endpoints, or just to make very, very specifically crafted
 requests.  For this reasons, C<http_request> exists.
 
-This returns either an HTTP::Response or a Future that will complete to one.
+This method respects the C<should_return_futures> attributes of the
+JMAP::Tester object, and in futures mode will return a future that will resolve
+to the HTTP::Response.
 
 =cut
 
@@ -893,7 +926,7 @@ sub http_request {
   my ($self, $http_request) = @_;
 
   my $future = $self->ua->request($self, $http_request, 'misc');
-  return $self->return_futures ? $future : $future->$Failsafe->get;
+  return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 
 =method http_get

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -99,8 +99,8 @@ has should_return_futures => (
 # We use Future->fail because that way we can use ->else in chains to only act
 # on successful HTTP calls. At the end, it's fine if you're expecting a future
 # and can know that a failed future is a fail and a done future is okay. In the
-# old calling convention, though, you expect to get a success/fail object no
-# matter what, and unexpected behavior is fatal.
+# old calling convention, though, you expect to get a success/fail object as
+# long as you got an HTTP response.  Otherwise, you'd get an exception.
 #
 # $Failsafe emulates that. Just before we return from a future-returning
 # method, and if the client is not set to return futures, we do this:

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -916,9 +916,12 @@ connection.  This might be to interact with a custom authentication mechanism,
 to access custom endpoints, or just to make very, very specifically crafted
 requests.  For this reasons, C<http_request> exists.
 
+Pass this method an L<HTTP::Request> and it will use the tester's UA object to
+make the request.
+
 This method respects the C<should_return_futures> attributes of the
 JMAP::Tester object, and in futures mode will return a future that will resolve
-to the HTTP::Response.
+to the L<HTTP::Response>.
 
 =cut
 

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -366,6 +366,8 @@ sub request {
 
 sub munge_method_triple {}
 
+sub response_class { 'JMAP::Tester::Response' }
+
 sub _jresponse_from_hresponse {
   my ($self, $http_res) = @_;
 
@@ -391,7 +393,7 @@ sub _jresponse_from_hresponse {
     http_response => $http_res,
   });
 
-  return JMAP::Tester::Response->new({
+  return $self->response_class->new({
     items => $items,
     http_response       => $http_res,
     wrapper_properties  => $props,

--- a/lib/JMAP/Tester/Logger/HTTP.pm
+++ b/lib/JMAP/Tester/Logger/HTTP.pm
@@ -17,7 +17,7 @@ sub _log_generic {
   return;
 }
 
-for my $which (qw(jmap upload download)) {
+for my $which (qw(jmap misc upload download)) {
   for my $what (qw(request response)) {
     my $method = "log_${which}_${what}";
     no strict 'refs';

--- a/lib/JMAP/Tester/Logger/Null.pm
+++ b/lib/JMAP/Tester/Logger/Null.pm
@@ -8,6 +8,9 @@ use namespace::clean;
 sub log_jmap_request  {}
 sub log_jmap_response {}
 
+sub log_misc_request  {}
+sub log_misc_response {}
+
 sub log_upload_request  {}
 sub log_upload_response {}
 

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,21 +40,21 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
-my $DEFAULT_DIAG_GENERATOR = sub {
+my $DEFAULT_DIAG_DUMPER = sub {
   require JSON::MaybeXS;
   state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
-  return [ "Response sentences: " . $json->encode([ $_[0]->items ]) ];
+  return $json->encode($_[0]);
 };
 
-has _diagnostics_generator => (
+has _diagnostic_dumper => (
   is => 'ro',
-  default   => sub { $DEFAULT_DIAG_GENERATOR },
-  init_arg  => 'diagnostics_generator',
+  default   => sub { $DEFAULT_DIAG_DUMPER },
+  init_arg  => 'diagnostic_dumper',
 );
 
-sub generate_diagnostics {
-  my ($self) = @_;
-  $self->_diagnostics_generator->($self);
+sub dump_diagnostic {
+  my ($self, $value) = @_;
+  $self->_diagnostic_dumper->($value);
 }
 
 sub sentence_broker;

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,15 +40,19 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
-my $DEFAULT_DIAG_DUMPER = sub {
-  require JSON::MaybeXS;
-  state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
-  return $json->encode($_[0]);
-};
+sub default_diagnostic_dumper {
+  state $default = do {
+    require JSON::MaybeXS;
+    state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
+    sub { $json->encode($_[0]); }
+  };
+
+  return $default;
+}
 
 has _diagnostic_dumper => (
   is => 'ro',
-  default   => sub { $DEFAULT_DIAG_DUMPER },
+  builder   => 'default_diagnostic_dumper',
   init_arg  => 'diagnostic_dumper',
 );
 

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,6 +40,23 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
+my $DEFAULT_DIAG_GENERATOR = sub {
+  require JSON::MaybeXS;
+  state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
+  return [ "Response sentences: " . $json->encode([ $_[0]->items ]) ];
+};
+
+has _diagnostics_generator => (
+  is => 'ro',
+  default   => sub { $DEFAULT_DIAG_GENERATOR },
+  init_arg  => 'diagnostics_generator',
+);
+
+sub generate_diagnostics {
+  my ($self) = @_;
+  $self->_diagnostics_generator->($self);
+}
+
 sub sentence_broker;
 has sentence_broker => (
   is    => 'ro',

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,8 +40,15 @@ sub add_items {
   $_[0]->sentence_broker->abort_callback->("can't add items to " . __PACKAGE__);
 }
 
-sub sentence_broker {
-  state $BROKER = JMAP::Tester::SentenceBroker->new;
-}
+sub sentence_broker;
+has sentence_broker => (
+  is    => 'ro',
+  lazy  => 1,
+  init_arg => undef,
+  default  => sub {
+    my ($self) = @_;
+    JMAP::Tester::SentenceBroker->new({ response => $self });
+  },
+);
 
 1;

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -37,7 +37,7 @@ has wrapper_properties => (
 sub items { @{ $_[0]->_items } }
 
 sub add_items {
-  $_[0]->sentence_broker->abort_callback->("can't add items to " . __PACKAGE__);
+  $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
 sub sentence_broker;

--- a/lib/JMAP/Tester/Response/Sentence.pm
+++ b/lib/JMAP/Tester/Response/Sentence.pm
@@ -85,7 +85,7 @@ sub as_set {
   my ($self) = @_;
 
   unless ($self->name =~ m{/set$}) {
-    return $self->sentence_broker->abort_callback->(
+    return $self->sentence_broker->abort(
       sprintf(qq{tried to call ->as_set on sentence named "%s"}, $self->name)
     );
   }
@@ -116,7 +116,7 @@ sub assert_named {
 
   return $self if $self->name eq $name;
 
-  $self->sentence_broker->abort_callback->(
+  $self->sentence_broker->abort(
     sprintf qq{expected sentence named "%s" but got "%s"}, $name, $self->name
   );
 }

--- a/lib/JMAP/Tester/Response/Sentence/Set.pm
+++ b/lib/JMAP/Tester/Response/Sentence/Set.pm
@@ -162,10 +162,10 @@ sub assert_no_errors {
 
   return $self unless @errors;
 
-  $self->sentence_broker->abort_callback->({
-    message     => "errors found in " . $self->name . " sentence",
-    diagnostics => \@errors,
-  });
+  $self->sentence_broker->abort(
+    "errors found in " . $self->name . " sentence",
+    \@errors,
+  );
 }
 
 1;

--- a/lib/JMAP/Tester/Role/SentenceBroker.pm
+++ b/lib/JMAP/Tester/Role/SentenceBroker.pm
@@ -8,6 +8,6 @@ requires 'paragraph_for_items';
 
 requires 'strip_json_types';
 
-requires 'abort_callback';
+requires 'abort';
 
 1;

--- a/lib/JMAP/Tester/Role/SentenceCollection.pm
+++ b/lib/JMAP/Tester/Role/SentenceCollection.pm
@@ -10,8 +10,9 @@ BEGIN {
     sentence_for_item
     paragraph_for_items
 
-    abort_callback
     strip_json_types
+
+    abort
   )) {
     my $sub = sub {
       my $self = shift;
@@ -51,7 +52,7 @@ sub _index_setup {
 
     if (defined $prev_cid && $prev_cid ne $cid) {
       # We're transition from cid1 to cid2. -- rjbs, 2016-04-08
-      $self->abort_callback->("client_id <$cid> appears in non-contiguous positions")
+      $self->abort("client_id <$cid> appears in non-contiguous positions")
         if $cid_indices{$cid};
 
       $next_para_idx++;
@@ -86,7 +87,7 @@ sub sentence {
   my ($self, $n) = @_;
 
   my @items = $self->items;
-  $self->abort_callback->("there is no sentence for index $n")
+  $self->abort("there is no sentence for index $n")
     unless my $item = $items[$n];
 
   return $self->sentence_for_item($item);
@@ -126,7 +127,7 @@ sub single_sentence {
 
   my @items = $self->items;
   unless (@items == 1) {
-    $self->abort_callback->(
+    $self->abort(
       sprintf("single_sentence called but there are %i sentences", 0+@items)
     );
   }
@@ -135,7 +136,7 @@ sub single_sentence {
 
   my $have = $sentence->name;
   if (defined $name && $have ne $name) {
-    $self->abort_callback->(qq{single sentence has name "$have" not "$name"});
+    $self->abort(qq{single sentence has name "$have" not "$name"});
   }
 
   return $sentence;
@@ -158,11 +159,11 @@ sub sentence_named {
   my @sentences = grep {; $_->name eq $name } $self->sentences;
 
   unless (@sentences) {
-    $self->abort_callback->(qq{no sentence found with name "$name"});
+    $self->abort(qq{no sentence found with name "$name"});
   }
 
   if (@sentences > 1) {
-    $self->abort_callback->(qq{found more than one sentence with name "$name"});
+    $self->abort(qq{found more than one sentence with name "$name"});
   }
 
   return $sentences[0];
@@ -185,7 +186,7 @@ sub assert_n_sentences {
   my @sentences = $self->sentences;
 
   unless (@sentences == $n) {
-    $self->abort_callback->("expected $n sentences but got " . @sentences)
+    $self->abort("expected $n sentences but got " . @sentences)
   }
 
   return @sentences;
@@ -203,7 +204,7 @@ of the response.
 sub paragraph {
   my ($self, $n) = @_;
 
-  $self->abort_callback->("there is no paragraph for index $n")
+  $self->abort("there is no paragraph for index $n")
     unless my $indices = $self->_para_indices->[$n];
 
   my @items    = $self->items;
@@ -252,7 +253,7 @@ sub assert_n_paragraphs {
 
   my @para_indices = @{ $self->_para_indices };
   unless ($n == @para_indices) {
-    $self->abort_callback->("expected $n paragraphs but got " . @para_indices)
+    $self->abort("expected $n paragraphs but got " . @para_indices)
   }
 
   return $self->paragraphs;
@@ -272,7 +273,7 @@ sub paragraph_by_client_id {
 
   Carp::confess("no client id given") unless defined $cid;
 
-  $self->abort_callback->("there is no paragraph for client_id $cid")
+  $self->abort("there is no paragraph for client_id $cid")
     unless my $indices = $self->_cid_indices->{$cid};
 
   my @items    = $self->items;

--- a/lib/JMAP/Tester/Role/UA.pm
+++ b/lib/JMAP/Tester/Role/UA.pm
@@ -11,5 +11,8 @@ requires qw( request );
 # Is this a terrible idea?
 requires qw( set_cookie );
 
+# Is this also a terrible idea?
+requires qw( set_default_header );
+
 no Moo::Role;
 1;

--- a/lib/JMAP/Tester/Role/UA.pm
+++ b/lib/JMAP/Tester/Role/UA.pm
@@ -10,6 +10,7 @@ requires qw( request );
 
 # Is this a terrible idea?
 requires qw( set_cookie );
+requires qw( scan_cookies );
 
 # Is this also a terrible idea?
 requires qw( set_default_header );

--- a/lib/JMAP/Tester/Role/UA.pm
+++ b/lib/JMAP/Tester/Role/UA.pm
@@ -1,0 +1,15 @@
+use v5.10.0;
+use warnings;
+
+package JMAP::Tester::Role::UA;
+
+use Moo::Role;
+
+# $ua->request( HTTP::Request ) returns Future( HTTP::Response )
+requires qw( request );
+
+# Is this a terrible idea?
+requires qw( set_cookie );
+
+no Moo::Role;
+1;

--- a/lib/JMAP/Tester/Role/UA.pm
+++ b/lib/JMAP/Tester/Role/UA.pm
@@ -13,6 +13,7 @@ requires qw( set_cookie );
 requires qw( scan_cookies );
 
 # Is this also a terrible idea?
+requires qw( get_default_header );
 requires qw( set_default_header );
 
 no Moo::Role;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -40,4 +40,4 @@ sub strip_json_types {
 }
 
 no Moo;
-1;
+__PACKAGE__->meta->make_immutable;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -82,4 +82,4 @@ sub strip_json_types {
 }
 
 no Moo;
-__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -4,7 +4,7 @@ package JMAP::Tester::SentenceBroker;
 use Moo;
 with 'JMAP::Tester::Role::SentenceBroker';
 
-use JMAP::Tester::Abort 'abort';
+use JMAP::Tester::Abort;
 use JMAP::Tester::Response::Sentence;
 use JMAP::Tester::Response::Paragraph;
 
@@ -38,7 +38,14 @@ sub paragraph_for_items {
   });
 }
 
-sub abort_callback { \&abort }
+sub abort {
+  my ($self, $string, $diagnostics) = @_;
+
+  die JMAP::Tester::Abort->new({
+    message => $string,
+    ($diagnostics ? (diagnostics => $diagnostics) : ()),
+  });
+}
 
 sub strip_json_types {
   state $typist = JSON::Typist->new;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -8,6 +8,12 @@ use JMAP::Tester::Abort 'abort';
 use JMAP::Tester::Response::Sentence;
 use JMAP::Tester::Response::Paragraph;
 
+has response => (
+  is => 'ro',
+  weak_ref => 1,
+  required => 1,
+);
+
 sub client_ids_for_items {
   map {; $_->[2] } @{ $_[1] }
 }

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -41,6 +41,12 @@ sub paragraph_for_items {
 sub abort {
   my ($self, $string, $diagnostics) = @_;
 
+  unless ($diagnostics) {
+    # We should decide what should be passed in, if anything.  Probably
+    # something, right?
+    $diagnostics = $self->response->generate_diagnostics();
+  }
+
   die JMAP::Tester::Abort->new({
     message => $string,
     ($diagnostics ? (diagnostics => $diagnostics) : ()),

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -1,0 +1,65 @@
+use v5.10.0;
+use warnings;
+
+package JMAP::Tester::UA::Async;
+
+use Moo;
+with 'JMAP::Tester::Role::UA';
+
+use Future;
+
+has client => (
+  is   => 'ro',
+  required => 1,
+);
+
+sub set_cookie {
+  my ($self, $arg) = @_;
+
+  for (qw(api_uri name value)) {
+    Carp::confess("can't set_cookie without $_") unless $arg->{$_};
+  }
+
+  my $uri = URI->new($arg->{api_uri});
+
+  $self->client->cookie_jar->set_cookie(
+    1,
+    $arg->{name},
+    $arg->{value},
+    '/',
+    $arg->{domain} // $uri->host,
+    $uri->port,
+    0,
+    ($uri->port == 443 ? 1 : 0),
+    86400,
+    0,
+    $arg->{rest} || {},
+  );
+}
+
+sub request {
+  my ($self, $tester, $req, $log_type, $log_extra) = @_;
+
+  my $logger = $tester->_logger;
+
+  my $log_method = "log_" . ($log_type // 'jmap') . '_request';
+  $self->ua->set_my_handler(request_send => sub {
+    my ($req) = @_;
+    $logger->$log_method({
+      ($log_extra ? %$log_extra : ()),
+      http_request => $req,
+    });
+    return;
+  });
+
+  my $http_res = $self->lwp->request($post);
+
+  # Clear our handler, or it will get called for
+  # any http request our ua makes!
+  $self->ua->set_my_handler(request_send => undef);
+
+  return Future->done($http_res);
+}
+
+no Moo;
+1;

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -8,7 +8,7 @@ with 'JMAP::Tester::Role::UA';
 
 use Future;
 
-has client => (
+has http_client => (
   is   => 'ro',
   required => 1,
 );
@@ -22,7 +22,7 @@ sub set_cookie {
 
   my $uri = URI->new($arg->{api_uri});
 
-  $self->client->cookie_jar->set_cookie(
+  $self->http_client->cookie_jar->set_cookie(
     1,
     $arg->{name},
     $arg->{value},
@@ -39,7 +39,7 @@ sub set_cookie {
 
 sub scan_cookies {
   my ($self, $callback) = @_;
-  return $self->client->cookie_jar->scan($callback);
+  return $self->http_client->cookie_jar->scan($callback);
 }
 
 has _default_headers => (
@@ -71,7 +71,7 @@ sub request {
 
   my $log_method = "log_" . ($log_type // 'jmap') . '_request';
 
-  return $self->client->do_request(
+  return $self->http_client->do_request(
     request => $req,
     on_ready => sub {
       # This fires just before the request is written to the socket, just

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -66,16 +66,22 @@ sub request {
 
   my $log_method = "log_" . ($log_type // 'jmap') . '_request';
 
-#  $self->ua->set_my_handler(request_send => sub {
-#    my ($req) = @_;
-#    $logger->$log_method({
-#      ($log_extra ? %$log_extra : ()),
-#      http_request => $req,
-#    });
-#    return;
-#  });
+  return $self->client->do_request(
+    request => $req,
+    on_ready => sub {
+      # This fires just before the request is written to the socket, just
+      # like how LWP::UserAgent logs the request before actually sending
+      # it
+      my $log_method = "log_" . ($log_type // 'jmap') . '_request';
 
-  return $self->client->do_request(request => $req);
+      $tester->_logger->$log_method({
+        ($log_extra ? %$log_extra : ()),
+        http_request => $req,
+      });
+
+      return Future->done;
+    },
+  );
 }
 
 no Moo;

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -47,6 +47,12 @@ has _default_headers => (
   default => sub {  {}  },
 );
 
+sub get_default_header {
+  my ($self, $name) = @_;
+
+  return scalar $self->_default_headers->{$name};
+}
+
 sub set_default_header {
   my ($self, $name, $value) = @_;
 

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -37,8 +37,30 @@ sub set_cookie {
   );
 }
 
+has _default_headers => (
+  is => 'ro',
+  default => sub {  {}  },
+);
+
+sub set_default_header {
+  my ($self, $name, $value) = @_;
+
+  if (defined $value) {
+    $self->_default_headers->{$name} = $value;
+  } else {
+    delete $self->_default_headers->{$name};
+  }
+
+  return;
+}
+
 sub request {
   my ($self, $tester, $req, $log_type, $log_extra) = @_;
+
+  my $dh = $self->_default_headers;
+  for my $h (keys %$dh) {
+    $req->header($h => $dh->{$h}) unless defined $req->header($h);
+  }
 
   my $logger = $tester->_logger;
 

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -22,7 +22,7 @@ sub set_cookie {
 
   my $uri = URI->new($arg->{api_uri});
 
-  $self->http_client->cookie_jar->set_cookie(
+  $self->http_client->{cookie_jar}->set_cookie(
     1,
     $arg->{name},
     $arg->{value},
@@ -39,7 +39,7 @@ sub set_cookie {
 
 sub scan_cookies {
   my ($self, $callback) = @_;
-  return $self->http_client->cookie_jar->scan($callback);
+  return $self->http_client->{cookie_jar}->scan($callback);
 }
 
 has _default_headers => (

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -37,6 +37,11 @@ sub set_cookie {
   );
 }
 
+sub scan_cookies {
+  my ($self, $callback) = @_;
+  return $self->client->cookie_jar->scan($callback);
+}
+
 has _default_headers => (
   is => 'ro',
   default => sub {  {}  },

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -43,22 +43,17 @@ sub request {
   my $logger = $tester->_logger;
 
   my $log_method = "log_" . ($log_type // 'jmap') . '_request';
-  $self->ua->set_my_handler(request_send => sub {
-    my ($req) = @_;
-    $logger->$log_method({
-      ($log_extra ? %$log_extra : ()),
-      http_request => $req,
-    });
-    return;
-  });
 
-  my $http_res = $self->lwp->request($post);
+#  $self->ua->set_my_handler(request_send => sub {
+#    my ($req) = @_;
+#    $logger->$log_method({
+#      ($log_extra ? %$log_extra : ()),
+#      http_request => $req,
+#    });
+#    return;
+#  });
 
-  # Clear our handler, or it will get called for
-  # any http request our ua makes!
-  $self->ua->set_my_handler(request_send => undef);
-
-  return Future->done($http_res);
+  return $self->client->do_request(request => $req);
 }
 
 no Moo;

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -44,7 +44,11 @@ sub scan_cookies {
 
 has _default_headers => (
   is => 'ro',
-  default => sub {  {}  },
+  default => sub {
+    {
+      'Content-Type' => 'application/json',
+    }
+  },
 );
 
 sub get_default_header {

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -89,10 +89,12 @@ sub request {
       # it
       my $log_method = "log_" . ($log_type // 'jmap') . '_request';
 
-      $tester->_logger->$log_method({
-        ($log_extra ? %$log_extra : ()),
-        http_request => $req,
-      });
+      if ($logger->can($log_method)) {
+        $tester->_logger->$log_method({
+          ($log_extra ? %$log_extra : ()),
+          http_request => $req,
+        });
+      }
 
       return Future->done;
     },

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -1,0 +1,78 @@
+use v5.10.0;
+use warnings;
+
+package JMAP::Tester::UA::LWP;
+
+use Moo;
+with 'JMAP::Tester::Role::UA';
+
+use Future;
+
+has lwp => (
+  is   => 'ro',
+  lazy => 1,
+  default => sub {
+    my ($self) = @_;
+
+    require LWP::UserAgent;
+    my $lwp = LWP::UserAgent->new;
+    $lwp->cookie_jar({});
+
+    if ($ENV{IGNORE_INVALID_CERT}) {
+      $lwp->ssl_opts(SSL_verify_mode => 0, verify_hostname => 0);
+    }
+
+    return $lwp;
+  },
+);
+
+sub set_cookie {
+  my ($self, $arg) = @_;
+
+  for (qw(api_uri name value)) {
+    Carp::confess("can't set_cookie without $_") unless $arg->{$_};
+  }
+
+  my $uri = URI->new($arg->{api_uri});
+
+  $self->lwp->cookie_jar->set_cookie(
+    1,
+    $arg->{name},
+    $arg->{value},
+    '/',
+    $arg->{domain} // $uri->host,
+    $uri->port,
+    0,
+    ($uri->port == 443 ? 1 : 0),
+    86400,
+    0,
+    $arg->{rest} || {},
+  );
+}
+
+sub request {
+  my ($self, $tester, $req, $log_type, $log_extra) = @_;
+
+  my $logger = $tester->_logger;
+
+  my $log_method = "log_" . ($log_type // 'jmap') . '_request';
+  $self->lwp->set_my_handler(request_send => sub {
+    my ($req) = @_;
+    $logger->$log_method({
+      ($log_extra ? %$log_extra : ()),
+      http_request => $req,
+    });
+    return;
+  });
+
+  my $http_res = $self->lwp->request($req);
+
+  # Clear our handler, or it will get called for
+  # any http request our ua makes!
+  $self->lwp->set_my_handler(request_send => undef);
+
+  return Future->done($http_res);
+}
+
+no Moo;
+1;

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -6,6 +6,7 @@ package JMAP::Tester::UA::LWP;
 use Moo;
 with 'JMAP::Tester::Role::UA';
 
+use Carp ();
 use Future;
 
 has lwp => (

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -59,17 +59,20 @@ sub set_default_header {
 sub request {
   my ($self, $tester, $req, $log_type, $log_extra) = @_;
 
+  Carp::cluck("something very strange happened") unless $tester->can('_logger');
   my $logger = $tester->_logger;
 
   my $log_method = "log_" . ($log_type // 'jmap') . '_request';
-  $self->lwp->set_my_handler(request_send => sub {
-    my ($req) = @_;
-    $logger->$log_method({
-      ($log_extra ? %$log_extra : ()),
-      http_request => $req,
+  if ($logger->can($log_method)) {
+    $self->lwp->set_my_handler(request_send => sub {
+      my ($req) = @_;
+      $logger->$log_method({
+        ($log_extra ? %$log_extra : ()),
+        http_request => $req,
+      });
+      return;
     });
-    return;
-  });
+  }
 
   my $http_res = $self->lwp->request($req);
 

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -50,6 +50,11 @@ sub set_cookie {
   );
 }
 
+sub scan_cookies {
+  my ($self, $callback) = @_;
+  return $self->lwp->cookie_jar->scan($callback);
+}
+
 sub set_default_header {
   my ($self, $name, $value) = @_;
 

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -54,6 +54,7 @@ sub set_default_header {
   my ($self, $name, $value) = @_;
 
   $self->lwp->default_header($name, $value);
+  return;
 }
 
 sub request {

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -19,6 +19,8 @@ has lwp => (
     my $lwp = LWP::UserAgent->new;
     $lwp->cookie_jar({});
 
+    $lwp->default_header('Content-Type' => 'application/json');
+
     if ($ENV{IGNORE_INVALID_CERT}) {
       $lwp->ssl_opts(SSL_verify_mode => 0, verify_hostname => 0);
     }

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -50,6 +50,12 @@ sub set_cookie {
   );
 }
 
+sub set_default_header {
+  my ($self, $name, $value) = @_;
+
+  $self->lwp->default_header($name, $value);
+}
+
 sub request {
   my ($self, $tester, $req, $log_type, $log_extra) = @_;
 

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -56,6 +56,12 @@ sub scan_cookies {
   return $self->lwp->cookie_jar->scan($callback);
 }
 
+sub get_default_header {
+  my ($self, $name) = @_;
+
+  return scalar $self->lwp->default_header($name);
+}
+
 sub set_default_header {
   my ($self, $name, $value) = @_;
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,11 +18,8 @@ use Test::Abortable 'subtest';
 # require mocking up a remote end.  Until we're up for doing that, this is
 # simpler for testing. -- rjbs, 2016-12-15
 
-my $broker = JMAP::Tester::SentenceBroker->new;
-
 subtest "the basic basics" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ jstr('atePies'),
         { howMany => jnum(100), tastiestPieId => jstr(123) },
@@ -161,7 +158,6 @@ subtest "old style updated" => sub {
 
   for my $kind (sort keys %kinds) {
     my $res = JMAP::Tester::Response->new({
-      sentence_broker => $broker,
       items => [
         [ 'Piece/set' => { updated => $kinds{$kind} }, 'a' ]
       ],
@@ -187,7 +183,6 @@ subtest "basic abort" => sub {
   my $events = Test2::API::intercept(sub {
     subtest "this will abort" => sub {
       my $res = JMAP::Tester::Response->new({
-        sentence_broker => $broker,
         items => [
           [ atePies => { howMany => jnum(100), tastiestPieId => jstr(123) }, 'a' ],
         ],
@@ -211,7 +206,6 @@ subtest "basic abort" => sub {
 
 subtest "set assert_named" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [
         'Piece/set' => {
@@ -238,7 +232,6 @@ subtest "set sentence assert_no_errors" => sub {
   my $events = Test2::API::intercept(sub {
     subtest "this will abort" => sub {
       my $res = JMAP::Tester::Response->new({
-        sentence_broker => $broker,
         items => [
           [
             'Piece/set' => {
@@ -275,7 +268,6 @@ subtest "set sentence assert_no_errors" => sub {
 
 subtest "calling as_set on non-set sentence" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [[
       error => {
         type => 'internal',
@@ -293,14 +285,12 @@ subtest "calling as_set on non-set sentence" => sub {
 
 subtest "miscellaneous error conditions" => sub {
   my $res_1 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all => jstr('refugees') }, jstr('xyzzy') ],
     ],
   });
 
   my $res_2 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all  => jstr('refugees') }, jstr('xyzzy') ],
       [ goodBye => { blue => jstr('skye') }, jstr('a') ],
@@ -342,7 +332,6 @@ subtest "miscellaneous error conditions" => sub {
   }
 
   my $res_3 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all => jstr('refugees') }, jstr('xyzzy') ],
       [ welcome => { all => jstr('homeless') }, jstr('xyzzy') ],


### PR DESCRIPTION
Okay, so probably this could be two commits, and maybe we can rewrite this commit later, but bear with me for now.

The end goal here is to allow the JMAP client to work in an async program, so that ->request can return a future that will resolve to the sentence collection when it's ready.  Meanwhile, the changes should not *seriously* break existing code.  So, it's okay if a small amount of mechanical change is needed for code that was calling things directly on the LWP object, but we shouldn't break every call to ->request in existing tests.

We accomplish this through a few steps.

First, we abstract out $tester->ua, previously a LWP::UserAgent object, into a thin adapter over the client of your choice.  LWP remains the default, but I've added a stub implementation for Net::Async::HTTP, which should work just fine, but will break logging.  (A few things in this commit worsen logging, some fatally for now.)

Next, we define the UA adapters to return futures, not responses.  The JMAP::Tester code that interprets those responses is then moved into a ->then sequence that hangs off the HTTP response.  Any user-facing method that works this way will either return a future or a Result, depending on the JMAP::Tester's return_futures setting.  The default is to return results, to match existing behavior.

If futures are returned, JMAP::Tester::Result::Failure objects show up as failures of the future.  If results are returned, Failure results may be returned, but other forms of failing futures will result in exceptions.  
