### PR TITLE
download: allow a uri_callback

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -581,6 +581,11 @@ sub download {
 
   my $uri = $self->download_uri_for($arg);
 
+  # This is useful if you need to, for example, sign the URLs
+  if (my $cb = $arg->{uri_callback}) {
+    $uri = $cb->($uri);
+  }
+
   my $get = HTTP::Request->new(
     GET => $uri,
     [


### PR DESCRIPTION
JWTs aren't part of the spec any more, and this is more general anyway.
I'm not removing the JWT stuff entirely, because a bunch of internal
code at Fastmail depends on it.