### PR TITLE
Make the use of JSON::Typist optional

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -89,10 +89,14 @@ has json_codec => (
   },
 );
 
+has use_json_typist => (
+  is => 'ro',
+  default => 1,
+);
+
 has _json_typist => (
   is => 'ro',
   handles => {
-    apply_json_types => 'apply_types',
     strip_json_types => 'strip_types',
   },
   default => sub {
@@ -100,6 +104,13 @@ has _json_typist => (
     return JSON::Typist->new;
   },
 );
+
+sub apply_json_types {
+  my ($self, $data) = @_;
+
+  return $data unless $self->use_json_typist;
+  return $self->_json_typist->apply_types($data);
+}
 
 for my $type (qw(api authentication download upload)) {
   has "$type\_uri" => (

--- a/t/basic.t
+++ b/t/basic.t
@@ -399,6 +399,39 @@ subtest "interpreting HTTP responses" => sub {
   }
 };
 
+subtest "with optional typist" => sub {
+  my $new_hres = sub {
+    return HTTP::Response->new(
+      200,
+      "OK",
+      [ 'Content-Type', 'application/json' ],
+      q<{"methodResponses": [["foo", {"a":1}, "c"]] }>,
+    );
+  };
+
+  {
+    my $tester = JMAP::Tester->new;
+    my $jres = $tester->_jresponse_from_hresponse($new_hres->());
+    ok(
+      $jres->as_pairs->[0][1]{a}->isa('JSON::Typist::Number'),
+      'default to using a typist'
+    );
+  }
+
+  {
+    my $tester = JMAP::Tester->new(use_json_typist => 0);
+    my $jres = $tester->_jresponse_from_hresponse($new_hres->());
+
+    # cmp_deeply doesn't see through types, so we can use it to assert we
+    # don't have them.
+    cmp_deeply(
+      $jres->as_pairs,
+      [ [ "foo", {a=>1} ] ],
+      'with false use_json_typist, we do not'
+    );
+  }
+};
+
 sub aborts_ok {
   my ($code, $want, $desc);
   if (@_ == 2) {


### PR DESCRIPTION
Testers now get a use_json_typist attribute. If it's true (the default),
we use JSON::Typist, as before; if it's not, we won't.