### PR TITLE
auto-diagnostics for thrown aborts

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -366,6 +366,8 @@ sub request {
 
 sub munge_method_triple {}
 
+sub response_class { 'JMAP::Tester::Response' }
+
 sub _jresponse_from_hresponse {
   my ($self, $http_res) = @_;
 
@@ -391,7 +393,7 @@ sub _jresponse_from_hresponse {
     http_response => $http_res,
   });
 
-  return JMAP::Tester::Response->new({
+  return $self->response_class->new({
     items => $items,
     http_response       => $http_res,
     wrapper_properties  => $props,

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,21 +40,21 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
-my $DEFAULT_DIAG_GENERATOR = sub {
+my $DEFAULT_DIAG_DUMPER = sub {
   require JSON::MaybeXS;
   state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
-  return [ "Response sentences: " . $json->encode([ $_[0]->items ]) ];
+  return $json->encode($_[0]);
 };
 
-has _diagnostics_generator => (
+has _diagnostic_dumper => (
   is => 'ro',
-  default   => sub { $DEFAULT_DIAG_GENERATOR },
-  init_arg  => 'diagnostics_generator',
+  default   => sub { $DEFAULT_DIAG_DUMPER },
+  init_arg  => 'diagnostic_dumper',
 );
 
-sub generate_diagnostics {
-  my ($self) = @_;
-  $self->_diagnostics_generator->($self);
+sub dump_diagnostic {
+  my ($self, $value) = @_;
+  $self->_diagnostic_dumper->($value);
 }
 
 sub sentence_broker;

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,15 +40,19 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
-my $DEFAULT_DIAG_DUMPER = sub {
-  require JSON::MaybeXS;
-  state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
-  return $json->encode($_[0]);
-};
+sub default_diagnostic_dumper {
+  state $default = do {
+    require JSON::MaybeXS;
+    state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
+    sub { $json->encode($_[0]); }
+  };
+
+  return $default;
+}
 
 has _diagnostic_dumper => (
   is => 'ro',
-  default   => sub { $DEFAULT_DIAG_DUMPER },
+  builder   => 'default_diagnostic_dumper',
   init_arg  => 'diagnostic_dumper',
 );
 

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,6 +40,23 @@ sub add_items {
   $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
+my $DEFAULT_DIAG_GENERATOR = sub {
+  require JSON::MaybeXS;
+  state $json = JSON::MaybeXS->new->utf8->convert_blessed->pretty->canonical;
+  return [ "Response sentences: " . $json->encode([ $_[0]->items ]) ];
+};
+
+has _diagnostics_generator => (
+  is => 'ro',
+  default   => sub { $DEFAULT_DIAG_GENERATOR },
+  init_arg  => 'diagnostics_generator',
+);
+
+sub generate_diagnostics {
+  my ($self) = @_;
+  $self->_diagnostics_generator->($self);
+}
+
 sub sentence_broker;
 has sentence_broker => (
   is    => 'ro',

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -40,8 +40,15 @@ sub add_items {
   $_[0]->sentence_broker->abort_callback->("can't add items to " . __PACKAGE__);
 }
 
-sub sentence_broker {
-  state $BROKER = JMAP::Tester::SentenceBroker->new;
-}
+sub sentence_broker;
+has sentence_broker => (
+  is    => 'ro',
+  lazy  => 1,
+  init_arg => undef,
+  default  => sub {
+    my ($self) = @_;
+    JMAP::Tester::SentenceBroker->new({ response => $self });
+  },
+);
 
 1;

--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -37,7 +37,7 @@ has wrapper_properties => (
 sub items { @{ $_[0]->_items } }
 
 sub add_items {
-  $_[0]->sentence_broker->abort_callback->("can't add items to " . __PACKAGE__);
+  $_[0]->sentence_broker->abort("can't add items to " . __PACKAGE__);
 }
 
 sub sentence_broker;

--- a/lib/JMAP/Tester/Response/Sentence.pm
+++ b/lib/JMAP/Tester/Response/Sentence.pm
@@ -85,7 +85,7 @@ sub as_set {
   my ($self) = @_;
 
   unless ($self->name =~ m{/set$}) {
-    return $self->sentence_broker->abort_callback->(
+    return $self->sentence_broker->abort(
       sprintf(qq{tried to call ->as_set on sentence named "%s"}, $self->name)
     );
   }
@@ -116,7 +116,7 @@ sub assert_named {
 
   return $self if $self->name eq $name;
 
-  $self->sentence_broker->abort_callback->(
+  $self->sentence_broker->abort(
     sprintf qq{expected sentence named "%s" but got "%s"}, $name, $self->name
   );
 }

--- a/lib/JMAP/Tester/Response/Sentence/Set.pm
+++ b/lib/JMAP/Tester/Response/Sentence/Set.pm
@@ -162,10 +162,10 @@ sub assert_no_errors {
 
   return $self unless @errors;
 
-  $self->sentence_broker->abort_callback->({
-    message     => "errors found in " . $self->name . " sentence",
-    diagnostics => \@errors,
-  });
+  $self->sentence_broker->abort(
+    "errors found in " . $self->name . " sentence",
+    \@errors,
+  );
 }
 
 1;

--- a/lib/JMAP/Tester/Role/SentenceBroker.pm
+++ b/lib/JMAP/Tester/Role/SentenceBroker.pm
@@ -8,6 +8,6 @@ requires 'paragraph_for_items';
 
 requires 'strip_json_types';
 
-requires 'abort_callback';
+requires 'abort';
 
 1;

--- a/lib/JMAP/Tester/Role/SentenceCollection.pm
+++ b/lib/JMAP/Tester/Role/SentenceCollection.pm
@@ -10,8 +10,9 @@ BEGIN {
     sentence_for_item
     paragraph_for_items
 
-    abort_callback
     strip_json_types
+
+    abort
   )) {
     my $sub = sub {
       my $self = shift;
@@ -51,7 +52,7 @@ sub _index_setup {
 
     if (defined $prev_cid && $prev_cid ne $cid) {
       # We're transition from cid1 to cid2. -- rjbs, 2016-04-08
-      $self->abort_callback->("client_id <$cid> appears in non-contiguous positions")
+      $self->abort("client_id <$cid> appears in non-contiguous positions")
         if $cid_indices{$cid};
 
       $next_para_idx++;
@@ -86,7 +87,7 @@ sub sentence {
   my ($self, $n) = @_;
 
   my @items = $self->items;
-  $self->abort_callback->("there is no sentence for index $n")
+  $self->abort("there is no sentence for index $n")
     unless my $item = $items[$n];
 
   return $self->sentence_for_item($item);
@@ -126,7 +127,7 @@ sub single_sentence {
 
   my @items = $self->items;
   unless (@items == 1) {
-    $self->abort_callback->(
+    $self->abort(
       sprintf("single_sentence called but there are %i sentences", 0+@items)
     );
   }
@@ -135,7 +136,7 @@ sub single_sentence {
 
   my $have = $sentence->name;
   if (defined $name && $have ne $name) {
-    $self->abort_callback->(qq{single sentence has name "$have" not "$name"});
+    $self->abort(qq{single sentence has name "$have" not "$name"});
   }
 
   return $sentence;
@@ -158,11 +159,11 @@ sub sentence_named {
   my @sentences = grep {; $_->name eq $name } $self->sentences;
 
   unless (@sentences) {
-    $self->abort_callback->(qq{no sentence found with name "$name"});
+    $self->abort(qq{no sentence found with name "$name"});
   }
 
   if (@sentences > 1) {
-    $self->abort_callback->(qq{found more than one sentence with name "$name"});
+    $self->abort(qq{found more than one sentence with name "$name"});
   }
 
   return $sentences[0];
@@ -185,7 +186,7 @@ sub assert_n_sentences {
   my @sentences = $self->sentences;
 
   unless (@sentences == $n) {
-    $self->abort_callback->("expected $n sentences but got " . @sentences)
+    $self->abort("expected $n sentences but got " . @sentences)
   }
 
   return @sentences;
@@ -203,7 +204,7 @@ of the response.
 sub paragraph {
   my ($self, $n) = @_;
 
-  $self->abort_callback->("there is no paragraph for index $n")
+  $self->abort("there is no paragraph for index $n")
     unless my $indices = $self->_para_indices->[$n];
 
   my @items    = $self->items;
@@ -252,7 +253,7 @@ sub assert_n_paragraphs {
 
   my @para_indices = @{ $self->_para_indices };
   unless ($n == @para_indices) {
-    $self->abort_callback->("expected $n paragraphs but got " . @para_indices)
+    $self->abort("expected $n paragraphs but got " . @para_indices)
   }
 
   return $self->paragraphs;
@@ -272,7 +273,7 @@ sub paragraph_by_client_id {
 
   Carp::confess("no client id given") unless defined $cid;
 
-  $self->abort_callback->("there is no paragraph for client_id $cid")
+  $self->abort("there is no paragraph for client_id $cid")
     unless my $indices = $self->_cid_indices->{$cid};
 
   my @items    = $self->items;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -40,4 +40,4 @@ sub strip_json_types {
 }
 
 no Moo;
-1;
+__PACKAGE__->meta->make_immutable;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -4,7 +4,7 @@ package JMAP::Tester::SentenceBroker;
 use Moo;
 with 'JMAP::Tester::Role::SentenceBroker';
 
-use JMAP::Tester::Abort 'abort';
+use JMAP::Tester::Abort;
 use JMAP::Tester::Response::Sentence;
 use JMAP::Tester::Response::Paragraph;
 
@@ -38,7 +38,14 @@ sub paragraph_for_items {
   });
 }
 
-sub abort_callback { \&abort }
+sub abort {
+  my ($self, $string, $diagnostics) = @_;
+
+  die JMAP::Tester::Abort->new({
+    message => $string,
+    ($diagnostics ? (diagnostics => $diagnostics) : ()),
+  });
+}
 
 sub strip_json_types {
   state $typist = JSON::Typist->new;

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -8,6 +8,12 @@ use JMAP::Tester::Abort 'abort';
 use JMAP::Tester::Response::Sentence;
 use JMAP::Tester::Response::Paragraph;
 
+has response => (
+  is => 'ro',
+  weak_ref => 1,
+  required => 1,
+);
+
 sub client_ids_for_items {
   map {; $_->[2] } @{ $_[1] }
 }

--- a/lib/JMAP/Tester/SentenceBroker.pm
+++ b/lib/JMAP/Tester/SentenceBroker.pm
@@ -41,6 +41,12 @@ sub paragraph_for_items {
 sub abort {
   my ($self, $string, $diagnostics) = @_;
 
+  unless ($diagnostics) {
+    # We should decide what should be passed in, if anything.  Probably
+    # something, right?
+    $diagnostics = $self->response->generate_diagnostics();
+  }
+
   die JMAP::Tester::Abort->new({
     message => $string,
     ($diagnostics ? (diagnostics => $diagnostics) : ()),

--- a/t/basic.t
+++ b/t/basic.t
@@ -18,11 +18,8 @@ use Test::Abortable 'subtest';
 # require mocking up a remote end.  Until we're up for doing that, this is
 # simpler for testing. -- rjbs, 2016-12-15
 
-my $broker = JMAP::Tester::SentenceBroker->new;
-
 subtest "the basic basics" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ jstr('atePies'),
         { howMany => jnum(100), tastiestPieId => jstr(123) },
@@ -161,7 +158,6 @@ subtest "old style updated" => sub {
 
   for my $kind (sort keys %kinds) {
     my $res = JMAP::Tester::Response->new({
-      sentence_broker => $broker,
       items => [
         [ 'Piece/set' => { updated => $kinds{$kind} }, 'a' ]
       ],
@@ -187,7 +183,6 @@ subtest "basic abort" => sub {
   my $events = Test2::API::intercept(sub {
     subtest "this will abort" => sub {
       my $res = JMAP::Tester::Response->new({
-        sentence_broker => $broker,
         items => [
           [ atePies => { howMany => jnum(100), tastiestPieId => jstr(123) }, 'a' ],
         ],
@@ -211,7 +206,6 @@ subtest "basic abort" => sub {
 
 subtest "set assert_named" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [
         'Piece/set' => {
@@ -238,7 +232,6 @@ subtest "set sentence assert_no_errors" => sub {
   my $events = Test2::API::intercept(sub {
     subtest "this will abort" => sub {
       my $res = JMAP::Tester::Response->new({
-        sentence_broker => $broker,
         items => [
           [
             'Piece/set' => {
@@ -275,7 +268,6 @@ subtest "set sentence assert_no_errors" => sub {
 
 subtest "calling as_set on non-set sentence" => sub {
   my $res = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [[
       error => {
         type => 'internal',
@@ -293,14 +285,12 @@ subtest "calling as_set on non-set sentence" => sub {
 
 subtest "miscellaneous error conditions" => sub {
   my $res_1 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all => jstr('refugees') }, jstr('xyzzy') ],
     ],
   });
 
   my $res_2 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all  => jstr('refugees') }, jstr('xyzzy') ],
       [ goodBye => { blue => jstr('skye') }, jstr('a') ],
@@ -342,7 +332,6 @@ subtest "miscellaneous error conditions" => sub {
   }
 
   my $res_3 = JMAP::Tester::Response->new({
-    sentence_broker => $broker,
     items => [
       [ welcome => { all => jstr('refugees') }, jstr('xyzzy') ],
       [ welcome => { all => jstr('homeless') }, jstr('xyzzy') ],


### PR DESCRIPTION
From a commit:

provide a pluggable diagnostics generator

* when no diagnostics are provided, provide some!
* let the provider be pluggable; starts with JSON, later Data::Printer?

The current pluggability of the diagnostician is not great.  I think it
should probably be something like:

1. you can replace the pretty printer from JSON to something else
2. you can, possibly per-abort, describe what diagnostics to generate

So maybe:

    $res = Result->new({
      ...,
      diagnostic_dumper => sub { ... },
      default_diagnostics => [
        'Response sentences' => sub ($res) { [ $res->items ] },
        ...
      ],
    });

Then diagnostics can be requested with:

    ->abort($message, [
      $label => $value,
      ...
    ]);

The second argument is a optlist (q.v. Data::OptList).  If there is no
value, the label is just a line.  If there is a value...

  ...if a subref, it's called with the $res as an argument.  The result
  is diagnostically dumpered.

  ...if another kind of ref, it's diagnostically dumpered.

We use OptList in part so that order is specified and not merely
cmp-based.
