### PR TITLE
Work around Role::Tiny@2.000006 bug with roles that have stub subs

### DIFF
--- a/lib/JMAP/Tester/Response.pm
+++ b/lib/JMAP/Tester/Response.pm
@@ -4,6 +4,26 @@ package JMAP::Tester::Response;
 # ABSTRACT: what you get in reply to a succesful JMAP request
 
 use Moo;
+
+# We can't use 'sub sentencebroker;' as a stub here as it conflicts
+# with older Role::Tiny versions (2.000006, 2.000008, and others).
+# With the stub, we'd see this error during compilation:
+#
+# Can't use string ("-1") as a symbol ref while "strict refs" in use at
+# /usr/share/perl5/Role/Tiny.pm line 382
+#
+# We could pin a newer Role::Tiny version but this fix is easy enough
+
+has sentence_broker => (
+  is    => 'ro',
+  lazy  => 1,
+  init_arg => undef,
+  default  => sub {
+    my ($self) = @_;
+    JMAP::Tester::SentenceBroker->new({ response => $self });
+  },
+);
+
 with 'JMAP::Tester::Role::SentenceCollection', 'JMAP::Tester::Role::HTTPResult';
 
 use JMAP::Tester::Response::Sentence;
@@ -60,16 +80,5 @@ sub dump_diagnostic {
   my ($self, $value) = @_;
   $self->_diagnostic_dumper->($value);
 }
-
-sub sentence_broker;
-has sentence_broker => (
-  is    => 'ro',
-  lazy  => 1,
-  init_arg => undef,
-  default  => sub {
-    my ($self) = @_;
-    JMAP::Tester::SentenceBroker->new({ response => $self });
-  },
-);
 
 1;


### PR DESCRIPTION
... by not declaring a stub and instead putting our has above
the 'with'.