### PR TITLE
remove "authentication_uri" from things configured by session

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -8,7 +8,6 @@ use Moo;
 
 use Crypt::Misc qw(decode_b64u encode_b64u);
 use Crypt::Mac::HMAC qw(hmac_b64u);
-use Digest::SHA ();
 use Encode qw(encode_utf8);
 use Future;
 use HTTP::Request;
@@ -528,6 +527,11 @@ to the Result.
 
 my %DL_DEFAULT = (name => 'download');
 
+sub _jwt_sub_param_from_uri {
+  my ($self, $to_sign) = @_;
+  "$to_sign";
+}
+
 sub download_uri_for {
   my ($self, $arg) = @_;
 
@@ -562,7 +566,7 @@ sub download_uri_for {
     my $payload = encode_b64u( $self->json_encode({
       iss => $jwtc->{signingId},
       iat => time,
-      sub => encode_b64u(Digest::SHA::sha256("$to_sign")),
+      sub => $self->_jwt_sub_param_from_uri($to_sign),
     }) );
 
     my $signature = hmac_b64u(

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -846,7 +846,7 @@ sub configure_from_client_session {
     $self->_jwt_config(undef);
   }
 
-  for my $type (qw(api authentication download upload)) {
+  for my $type (qw(api download upload)) {
     if (defined (my $uri = $client_session->{"${type}Url"})) {
       my $setter = "$type\_uri";
       $self->$setter($uri);

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -8,6 +8,7 @@ use Moo;
 
 use Crypt::Misc qw(decode_b64u encode_b64u);
 use Crypt::Mac::HMAC qw(hmac_b64u);
+use Digest::SHA ();
 use Encode qw(encode_utf8);
 use Future;
 use HTTP::Request;
@@ -561,7 +562,7 @@ sub download_uri_for {
     my $payload = encode_b64u( $self->json_encode({
       iss => $jwtc->{signingId},
       iat => time,
-      sub => "$to_sign",
+      sub => encode_b64u(Digest::SHA::sha256("$to_sign")),
     }) );
 
     my $signature = hmac_b64u(

--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -563,9 +563,12 @@ sub download_uri_for {
       typ => 'JWT',
     }) );
 
+    my $iat = time;
+    $iat = $iat - ($iat % 3600);
+
     my $payload = encode_b64u( $self->json_encode({
       iss => $jwtc->{signingId},
-      iat => time,
+      iat => $iat,
       sub => $self->_jwt_sub_param_from_uri($to_sign),
     }) );
 


### PR DESCRIPTION
This isn't stored in the session, so we'll always end up clearing it, which is no good!