### PR TITLE
Logger: add a tester ident and log it

### DIFF
--- a/lib/JMAP/Tester/Logger/HTTP.pm
+++ b/lib/JMAP/Tester/Logger/HTTP.pm
@@ -8,12 +8,13 @@ use namespace::clean;
 my %counter;
 
 sub _log_generic {
-  my ($self, $type, $thing) = @_;
+  my ($self, $tester, $type, $thing) = @_;
 
   my $i = $counter{$type}++;
-  $self->write("=== BEGIN \U$type\E $$.$i ===\n");
+  my $ident = $tester->ident;
+  $self->write("=== BEGIN \U$type\E $$.$i ($ident) ===\n");
   $self->write( $thing->as_string );
-  $self->write("=== END \U$type\E $$.$i ===\n");
+  $self->write("=== END \U$type\E $$.$i ($ident) ===\n");
   return;
 }
 
@@ -22,8 +23,8 @@ for my $which (qw(jmap misc upload download)) {
     my $method = "log_${which}_${what}";
     no strict 'refs';
     *$method = sub {
-      my ($self, $arg) = @_;
-      $self->_log_generic("$which $what", $arg->{"http_$what"});
+      my ($self, $tester, $arg) = @_;
+      $self->_log_generic($tester, "$which $what", $arg->{"http_$what"});
     }
   }
 }

--- a/lib/JMAP/Tester/UA/Async.pm
+++ b/lib/JMAP/Tester/UA/Async.pm
@@ -90,10 +90,13 @@ sub request {
       my $log_method = "log_" . ($log_type // 'jmap') . '_request';
 
       if ($logger->can($log_method)) {
-        $tester->_logger->$log_method({
-          ($log_extra ? %$log_extra : ()),
-          http_request => $req,
-        });
+        $tester->_logger->$log_method(
+          $tester,
+          {
+            ($log_extra ? %$log_extra : ()),
+            http_request => $req,
+          }
+        );
       }
 
       return Future->done;

--- a/lib/JMAP/Tester/UA/LWP.pm
+++ b/lib/JMAP/Tester/UA/LWP.pm
@@ -81,10 +81,13 @@ sub request {
   if ($logger->can($log_method)) {
     $self->lwp->set_my_handler(request_send => sub {
       my ($req) = @_;
-      $logger->$log_method({
-        ($log_extra ? %$log_extra : ()),
-        http_request => $req,
-      });
+      $logger->$log_method(
+        $tester,
+        {
+          ($log_extra ? %$log_extra : ()),
+          http_request => $req,
+        }
+      );
       return;
     });
   }


### PR DESCRIPTION
This way, you can create two testers and given them idents like "user client" and "entity client" and you'll know which bits of telemetry were logged by what client.

I am specifically writing this so that in the Cyrus Cassandane test system we can distinguish requests made by the test data generation client versus the requests made by explicit test code.