### PR TITLE
log the HTTP response from http_request (and thus http_get, http_post)

### DIFF
--- a/lib/JMAP/Tester.pm
+++ b/lib/JMAP/Tester.pm
@@ -935,7 +935,12 @@ to the L<HTTP::Response>.
 =cut
 
 sub http_request ($self, $http_request) {
-  my $future = $self->ua->request($self, $http_request, 'misc');
+  my $future = $self->ua->request($self, $http_request, 'misc')->then(sub {
+    my ($res) = @_;
+    $self->_logger->log_misc_response($self, { http_response => $res });
+    return Future->done($res);
+  });
+
   return $self->should_return_futures ? $future : $future->$Failsafe->get;
 }
 

--- a/lib/JMAP/Tester/Logger.pm
+++ b/lib/JMAP/Tester/Logger.pm
@@ -52,6 +52,9 @@ sub write ($self, $string) {
 requires 'log_jmap_request';
 requires 'log_jmap_response';
 
+requires 'log_misc_request';
+requires 'log_misc_response';
+
 requires 'log_upload_request';
 requires 'log_upload_response';
 

--- a/t/mock.t
+++ b/t/mock.t
@@ -140,7 +140,6 @@ subtest "uploading blobs" => sub {
   is($upload->size,    18,            "got the size we expect");
 };
 
-
 subtest 'http logger' => sub {
   my @lines;
 
@@ -152,6 +151,20 @@ subtest 'http logger' => sub {
   like($lines[0], qr/BEGIN JMAP REQUEST/, 'got our begin log line');
   like($lines[1], qr/Foo\/bar.*baz/, 'got our request');
   like($lines[2], qr/END JMAP REQUEST/, 'got our end log line');
+};
+
+subtest 'misc http logger' => sub {
+  my @lines;
+
+  local $tester->{_logger} = JMAP::Tester::Logger::HTTP->new({
+    writer => sub { push @lines, shift },
+  });
+
+  $tester->http_get($tester->authentication_uri);
+  like($lines[0], qr/BEGIN MISC REQUEST/,  'got our begin request log line');
+  like($lines[2], qr/END MISC REQUEST/,    'got our end request log line');
+  like($lines[3], qr/BEGIN MISC RESPONSE/, 'got our begin response log line');
+  like($lines[5], qr/END MISC RESPONSE/,   'got our end response log line');
 };
 
 done_testing;


### PR DESCRIPTION
The misc request was being logged via the UA handler, but the response was silently dropped on the floor, unlike upload/download/jmap responses which all called their corresponding log_*_response methods.

Also require log_misc_request and log_misc_response in the Logger role, consistent with all other request types.

(Came up while trying to debug some Fastmail Website stuff, which uses the tester's http_get.)